### PR TITLE
 Using the Java API for scripting in Elasticsearch 5.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 _site/
 Gemfile.lock
+.bundle
+vendor

--- a/README.textile
+++ b/README.textile
@@ -4,7 +4,7 @@ To set up the Jekyll-based blog locally, see "https://help.github.com/articles/s
 
 Quick setup:
 
-@sudo apt-get install ruby-dev@
+@sudo apt-get install build-essential zlib1g-dev ruby-dev@
 @sudo gem install bundler@
 @git clone https://github.com/lobid/lobid.github.com.git@
 @cd lobid.github.com@

--- a/_posts/2017-11-28-java-api-scripting-elasticsearch.md
+++ b/_posts/2017-11-28-java-api-scripting-elasticsearch.md
@@ -1,0 +1,49 @@
+---
+layout: post
+title: "Using the Java API for scripting in Elasticsearch 5.6"
+date: 2017-11-28
+author: Fabian Steeg
+---
+
+To create a custom aggregation [in lobid-resources for NWBib](https://github.com/hbz/lobid-resources/commit/72054407cd25371f58a28de0068a44ce8ada12bd), I used the Java API for scripting in Elasticsearch 5.6. It was surprisingly hard to find details on this, since there was no full, current documentation available. So here is the gist of it.
+
+First, we specify the scripting language to use, and a script ID:
+
+	String lang = "painless";
+	String id = "topic-aggregation";
+
+Then, our actual script content (as an example, we just pick the document's `type` field here):
+
+	String script = "doc['type']";
+
+Next, we have to create a JSON string to pass to the Elasticsearch API. Our goal is something like this:
+
+	{ "script": { "lang": "painless", "source": "doc['type']" } }
+
+To avoid escaping issues, we use a JSON lib here, like this:
+
+	ObjectNode scriptObject = Json.newObject();
+	scriptObject.putObject("script")
+		.put("lang", lang).put("source", script);
+
+We then wrap the JSON string into a `BytesArray` object:
+
+	BytesArray bytes = new BytesArray(scriptObject.toString());
+
+And finally use that object to store the script in our cluster:
+
+	PutStoredScriptResponse response = client.admin().cluster()
+		.preparePutStoredScript().setId(id)
+		.setContent(bytes, XContentType.JSON).get();
+
+Later, we can create a `Script` object based in the script ID:
+
+	Script script = new Script(
+		ScriptType.STORED, lang, id, Collections.emptyMap());
+
+Which we can then use, e.g. in our `Aggregation`:
+
+	searchRequest.addAggregation(
+		AggregationBuilders.terms("topic").script(script));
+
+For details on other Elasticsearch APIs and the painless scripting language, see [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/index.html).

--- a/_posts/2017-11-29-java-api-scripting-elasticsearch.md
+++ b/_posts/2017-11-29-java-api-scripting-elasticsearch.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Using the Java API for scripting in Elasticsearch 5.6"
-date: 2017-11-28
+date: 2017-11-29
 author: Fabian Steeg
 ---
 
@@ -46,4 +46,4 @@ Which we can then use, e.g. in our `Aggregation`:
 	searchRequest.addAggregation(
 		AggregationBuilders.terms("topic").script(script));
 
-For details on other Elasticsearch APIs and the painless scripting language, see [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/index.html).
+For details on other Elasticsearch APIs and the [painless scripting language](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/modules-scripting-painless.html), see [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/index.html).


### PR DESCRIPTION
Run locally with Jekyll (see instructions in README) for actual rendering as in production or see: https://github.com/lobid/lobid.github.com/blob/adfb8573aa2f0622bdc9543ef30652ee4b4affda/_posts/2017-11-28-java-api-scripting-elasticsearch.md